### PR TITLE
More robust hashing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.3.1"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 nauty_jll = "55c6dc9b-343a-50ca-8ff2-b71adb3733d5"
 

--- a/src/NautyGraphs.jl
+++ b/src/NautyGraphs.jl
@@ -1,6 +1,7 @@
 module NautyGraphs
 
 import nauty_jll
+using SHA
 const libnauty = nauty_jll.libnautyTL
 const WORDSIZE = 64
 const WordType = Culong

--- a/src/bitutils.jl
+++ b/src/bitutils.jl
@@ -115,6 +115,16 @@ function set_to_idxs!(set::AbstractVector{WordType}, idxs::AbstractVector{<:Inte
     return nidx
 end
 
+function _concatbytes(bytes::AbstractVector{<:UInt8})
+    @assert length(bytes) == sizeof(HashType)
+    w = HashType(0)
+    for b in bytes
+        w |= b
+        w <<= 8
+    end
+    return w
+end
+
 function _to_matrixidx(idx::Integer, m::Integer)
     return 1 + (idx - 1) ÷ m, mod1(idx, m)
 end

--- a/src/nauty.jl
+++ b/src/nauty.jl
@@ -117,6 +117,7 @@ end
 function _nautyhash(g::AbstractNautyGraph, h::UInt=zero(UInt))
     grpsize, canong, canon_perm = nauty(g, true)
     hashval = hash(view(g.labels, canon_perm), hash(canong, h))
+    g.hashval = hashval
     return grpsize, canong, canon_perm, hashval
 end
 
@@ -128,10 +129,8 @@ Reorder g's vertices to be in canonical order. Returns the permutation used to c
 """
 function canonize!(g::AbstractNautyGraph)
     grpsize, canong, canon_perm, hashval = _nautyhash(g)
-
-    g.graphset .= canong
-    g.labels .= g.labels[canon_perm]
-    g.hashval = hashval
+    copyto!(g.graphset, canong)
+    permute!(g.labels, canon_perm)
     return canon_perm, grpsize
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -85,3 +85,9 @@ function _modify_edge!(g::AbstractNautyGraph, e::Edge, add::Bool)
 
     return g.graphset[set_idx] != word_old
 end
+
+function hash_sha(x)
+    io = IOBuffer()
+    write(io, x)
+    return _concatbytes(sha256(take!(io))[1:8])
+end


### PR DESCRIPTION
Use (the first 64 bits of) sha256 to hash graphs whose data is stored in arrays of size >= 8192. 
(Using SHA on small graphs would lead to massive performance loss).