### PR TITLE
Better Defined Public Interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Maximilian HUEBL <maximilian.huebl@ist.ac.at>"]
 version = "0.4.0"
 
 [deps]
-Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -12,7 +11,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 nauty_jll = "55c6dc9b-343a-50ca-8ff2-b71adb3733d5"
 
 [compat]
-Downloads = "1.4"
 Graphs = "1.9"
 SparseArrays = "1.6"
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage](https://codecov.io/gh/mxhbl/NautyGraphs.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/mxhbl/NautyGraphs.jl)
 
 NautyGraphs.jl is a Julia interface to [_nauty_](https://pallini.di.uniroma1.it/) by Brendan McKay. It allows for efficient isomorphism checking, canonical labeling, and hashing of vertex-labeled graphs. In addition, NautyGraphs.jl is fully compatible with the [Graphs.jl](https://github.com/JuliaGraphs/Graphs.jl) API. This makes it easy to create or modify graphs through familiar syntax, and allows NautyGraphs to work with a large library of graph algorithms.
-**Warning**: NautyGraph.jl currently does not work on Windows. This will hopefully be fixed soon.
+**Warning**: NautyGraph.jl currently does not work on Windows.
 ## Installation
 To install NautyGraphs.jl from the Julia REPL, press `]` to enter Pkg mode, and then run
 ```
@@ -36,13 +36,13 @@ true
 julia> adjacency_matrix(g) == adjacency_matrix(h)
 false
 ```
-Use `canonize!(g)` to reorder `g` into canonical order. `canonize!(g)` also returns the permutation needed to canonize `g`, as well as the size of its automorphism group:
+Use `canonize!(g)` to reorder `g` into canonical order. `canonize!(g)` also returns the permutation needed to canonize `g`:
 ```
 julia> canonize!(g)
-([1, 3, 4, 2], 2)
+[1, 3, 4, 2]
 
 julia> canonize!(h)
-([2, 1, 3, 4], 2)
+[2, 1, 3, 4]
 
 julia> adjacency_matrix(g) == adjacency_matrix(h)
 true
@@ -55,6 +55,9 @@ julia> ghash(h)
 0x3127d9b726f2c846
 ```
 Graph hashes make it possible to quickly compare large numbers of graphs for isomorphism. Simply compute all hashes and filter out the duplicates!
+
+To obtain information about a graph's automorphism group, use `nauty(g)`. This will return the canonical permutation as well as an `AutomorphismGroup` object.
+Right now, the recorded properties of the automorphism group are very limited and only include the group size and orbits, but this will change in the future.
 
 ## See also
 - [_nauty_ & _traces_](https://pallini.di.uniroma1.it/)

--- a/src/NautyGraphs.jl
+++ b/src/NautyGraphs.jl
@@ -37,9 +37,4 @@ export
     is_isomorphic,
     ≃,
     ghash
-
-public 
-    NautyOptions
-    defaultoptions
-    
 end

--- a/src/NautyGraphs.jl
+++ b/src/NautyGraphs.jl
@@ -34,6 +34,7 @@ export
     labels,
     nauty,
     canonize!,
+    canonical_permutation,
     is_isomorphic,
     ≃,
     ghash

--- a/src/NautyGraphs.jl
+++ b/src/NautyGraphs.jl
@@ -21,8 +21,7 @@ const NautyDiGraph = DenseNautyGraph{true}
 function __init__()
     # global default options to nauty carry a pointer reference that needs to be initialized at runtime
     libnauty_dispatch = cglobal((:dispatch_graph, libnauty), Cvoid)
-    GRAPHDEFAULTOPTIONS.dispatch = libnauty_dispatch
-    DIGRAPHDEFAULTOPTIONS.dispatch = libnauty_dispatch
+    DEFAULT_OPTIONS.dispatch = libnauty_dispatch
     return
 end
 

--- a/src/NautyGraphs.jl
+++ b/src/NautyGraphs.jl
@@ -1,7 +1,8 @@
 module NautyGraphs
 
+using Graphs, SparseArrays, LinearAlgebra, SHA
 import nauty_jll
-using SHA
+
 const libnauty = nauty_jll.libnautyTL
 const WORDSIZE = 64
 const WordType = Culong
@@ -17,14 +18,28 @@ include("nauty.jl")
 const NautyGraph = DenseNautyGraph{false}
 const NautyDiGraph = DenseNautyGraph{true}
 
+function __init__()
+    # global default options to nauty carry a pointer reference that needs to be initialized at runtime
+    libnauty_dispatch = cglobal((:dispatch_graph, libnauty), Cvoid)
+    GRAPHDEFAULTOPTIONS.dispatch = libnauty_dispatch
+    DIGRAPHDEFAULTOPTIONS.dispatch = libnauty_dispatch
+    return
+end
+
 export
     AbstractNautyGraph,
     NautyGraph,
     NautyDiGraph,
+    AutomorphismGroup,
     labels,
     nauty,
     canonize!,
     is_isomorphic,
     ≃,
     ghash
+
+public 
+    NautyOptions
+    defaultoptions
+    
 end

--- a/src/densenautygraphs.jl
+++ b/src/densenautygraphs.jl
@@ -57,7 +57,14 @@ function DenseNautyGraph{D}(adjmx::AbstractMatrix, vertex_labels::Union{Vector{<
     return DenseNautyGraph(graphset, labels, D)
 end
 
-(::Type{G})(g::AbstractGraph, vertex_labels::Union{Vector{<:Integer},Nothing}=nothing) where {G<:AbstractNautyGraph} = G(adjacency_matrix(g), vertex_labels)
+function (::Type{G})(g::AbstractGraph, vertex_labels::Union{Vector{<:Integer},Nothing}=nothing) where {G<:AbstractNautyGraph}
+    ng = G(nv(g), vertex_labels)
+
+    for e in edges(g)
+        add_edge!(ng, e)
+    end
+    return ng
+end 
 
 Base.copy(g::G) where {G<:DenseNautyGraph} = G(copy(g.graphset), g.n_vertices, g.n_edges, g.n_words, copy(g.labels), g.hashval)
 function Base.copy!(dest::G, src::G) where {G<:DenseNautyGraph}

--- a/src/densenautygraphs.jl
+++ b/src/densenautygraphs.jl
@@ -40,15 +40,12 @@ function DenseNautyGraph{D}(n::Integer, vertex_labels::Union{Vector{<:Integer},N
     return DenseNautyGraph(graphset, labels, D)
 end
 function DenseNautyGraph{D}(adjmx::AbstractMatrix, vertex_labels::Union{Vector{<:Integer},Nothing}=nothing) where {D}
-    n, _n = size(adjmx)
-
-    # Self loops are not allowed
-    @assert all(iszero, diag(adjmx))
+    n, n2 = size(adjmx)
 
     if !D
-        @assert adjmx == adjmx'
+        @assert issymmetric(adjmx)
     else
-        @assert n == _n
+        @assert n == n2
     end
     
     graphset = _adjmatrix_to_graphset(adjmx)
@@ -169,8 +166,13 @@ begin # GRAPH MODIFY METHODS
     end
     function Graphs.add_edge!(g::DenseNautyGraph{false}, e::Edge)
         fwd_edge_added = _modify_edge!(g, e, true)
-        bwd_edge_added = _modify_edge!(g, reverse(e), true)
-        edge_added = fwd_edge_added && bwd_edge_added
+
+        if e.src != e.dst
+            bwd_edge_added = _modify_edge!(g, reverse(e), true)
+            edge_added = fwd_edge_added && bwd_edge_added
+        else
+            edge_added = fwd_edge_added
+        end
 
         if edge_added
             g.n_edges += 1

--- a/src/densenautygraphs.jl
+++ b/src/densenautygraphs.jl
@@ -157,7 +157,7 @@ begin # BASIC GRAPH API
     Base.zero(::G) where {G<:AbstractNautyGraph} = G(0)
     Base.zero(::Type{G}) where {G<:AbstractNautyGraph} = G(0)
 
-    function Graphs.adjacency_matrix(g::DenseNautyGraph, T::DataType=Int; dir::Symbol=:out)
+    function Graphs.adjacency_matrix(g::DenseNautyGraph, T::DataType=Int)
         n = nv(g)
     
         es = _directed_edges(g)
@@ -323,7 +323,7 @@ function Graphs.blockdiag(g::G, h::G) where {G<:DenseNautyGraph}
     return k
 end
 function blockdiag!(g::G, h::G) where {G<:DenseNautyGraph}
-    @assert g !== h # Make sure g and h are different objects (TODO: could be lifted)
+    @assert g !== h # Make sure g and h don't alias the same memory.
 
     for i in vertices(h)
         add_vertex!(g, h.labels[i])

--- a/src/densenautygraphs.jl
+++ b/src/densenautygraphs.jl
@@ -1,6 +1,3 @@
-using Graphs
-using SparseArrays, LinearAlgebra
-
 abstract type AbstractNautyGraph <: AbstractGraph{Cint} end
 # TODO: abstract type AbstractSparseNautyGraph <: AbstractNautyGraph end
 
@@ -75,6 +72,9 @@ end
 
 Base.show(io::Core.IO, g::DenseNautyGraph{false}) = print(io, "{$(nv(g)), $(ne(g))} undirected NautyGraph")
 Base.show(io::Core.IO, g::DenseNautyGraph{true}) = print(io, "{$(nv(g)), $(ne(g))} directed NautyGraph")
+
+Base.hash(g::DenseNautyGraph, h::UInt) = hash(g.labels, hash(g.graphset, h))
+Base.:(==)(g::DenseNautyGraph, h::DenseNautyGraph) = (g.graphset == h.graphset) && (g.labels == h.labels)
 
 begin # BASIC GRAPH API
     labels(g::AbstractNautyGraph) = g.labels

--- a/src/densenautygraphs.jl
+++ b/src/densenautygraphs.jl
@@ -58,13 +58,17 @@ function DenseNautyGraph{D}(adjmx::AbstractMatrix, vertex_labels::Union{Vector{<
 end
 
 function (::Type{G})(g::AbstractGraph, vertex_labels::Union{Vector{<:Integer},Nothing}=nothing) where {G<:AbstractNautyGraph}
+    if is_directed(g) != is_directed(G)
+        error("Cannot create an undirected NautyGraph from a directed graph (or vice versa). Please make sure the directedness of the graph types is matching.")
+    end
+
     ng = G(nv(g), vertex_labels)
 
     for e in edges(g)
         add_edge!(ng, e)
     end
     return ng
-end 
+end
 
 Base.copy(g::G) where {G<:DenseNautyGraph} = G(copy(g.graphset), g.n_vertices, g.n_edges, g.n_words, copy(g.labels), g.hashval)
 function Base.copy!(dest::G, src::G) where {G<:DenseNautyGraph}

--- a/src/densenautygraphs.jl
+++ b/src/densenautygraphs.jl
@@ -311,6 +311,12 @@ function Graphs.blockdiag(g::G, h::G) where {G<:DenseNautyGraph}
     k.n_edges = g.n_edges + h.n_edges
     return k
 end
+
+"""
+    blockdiag!(g::G, h::G) where {G<:DenseNautyGraph}
+
+Compute `blockdiag(g, h)` and store it in `g`, whose size is increased to accomodate it.
+"""
 function blockdiag!(g::G, h::G) where {G<:DenseNautyGraph}
     @assert g !== h # Make sure g and h don't alias the same memory.
 

--- a/src/densenautygraphs.jl
+++ b/src/densenautygraphs.jl
@@ -156,19 +156,6 @@ begin # BASIC GRAPH API
     Base.eltype(::AbstractNautyGraph) = Cint
     Base.zero(::G) where {G<:AbstractNautyGraph} = G(0)
     Base.zero(::Type{G}) where {G<:AbstractNautyGraph} = G(0)
-
-    function Graphs.adjacency_matrix(g::DenseNautyGraph, T::DataType=Int)
-        n = nv(g)
-    
-        es = _directed_edges(g)
-        k = length(es)
-        is, js, vals = zeros(T, k), zeros(T, k), ones(T, k)
-        for (i, e) in enumerate(es)
-            is[i] = e.src
-            js[i] = e.dst
-        end
-        return sparse(is, js, vals, n, n)
-    end
 end
 
 begin # GRAPH MODIFY METHODS

--- a/src/nauty.jl
+++ b/src/nauty.jl
@@ -1,5 +1,5 @@
 mutable struct NautyOptions
-    getcanon::Cint
+    getcanon::Cint # Warning: setting getcanon to false means that nauty will NOT compute the canonical representative, which may lead to unexpected results.
     digraph::Cbool
     writeautoms::Cbool
     writemarkers::Cbool
@@ -25,14 +25,20 @@ mutable struct NautyOptions
     schreier::Cbool
     extra_options::Ptr{Cvoid}
 
-    NautyOptions() = new(
-        0, false, false, false, true, false, 78,
+    NautyOptions(; digraph, ignorelabels=false, groupinfo=false) = new(
+        1, digraph, groupinfo, false, ignorelabels, false, 78,
         C_NULL, C_NULL, C_NULL, C_NULL, C_NULL, C_NULL, C_NULL,
         100, 0, 1, 0,
-        C_NULL,
+        cglobal((:dispatch_graph, libnauty), Cvoid),
         false, C_NULL
     )
 end
+
+const GRAPHDEFAULTOPTIONS = NautyOptions(digraph=false)
+const DIGRAPHDEFAULTOPTIONS = NautyOptions(digraph=true)
+
+defaultoptions(g::DenseNautyGraph) = is_directed(g) ? DIGRAPHDEFAULTOPTIONS : GRAPHDEFAULTOPTIONS
+
 mutable struct NautyStatistics
     grpsize1::Cdouble
     grpsize2::Cint
@@ -53,35 +59,19 @@ mutable struct NautyStatistics
     )
 end
 
-# TODO: Make this useful
-# struct AutomorphismGroup{T<:Integer}
-#     n::T
-#     orbits::Vector{T}
-#     generators::T
-#     # ... 
-# end
+struct AutomorphismGroup
+    n::Float64
+    orbits::Vector{Cint}
+    # generators::Vector{Vector{Cint}} #TODO: not implemented
+end
 
-
-"""
-    nauty(g::DenseNautyGraph, canonical_form=true; ignore_vertex_labels=false, kwargs...)
-
-Compute a graph g's automorphism group and its canonical form.
-"""
-function nauty(g::DenseNautyGraph, canonical_form=true; ignore_vertex_labels=false, kwargs...) # TODO: allow nautyoptions to be overwritten
+function _densenauty(g::DenseNautyGraph, options::NautyOptions=defaultoptions(g), statistics::NautyStatistics=NautyStatistics())
+    # TODO: allow the user to pass pre-allocated arrays for lab, ptn, orbits, canong in a safe way.
     n, m = g.n_vertices, g.n_words
 
-    options = NautyOptions() # TODO: allocate default options outside and make sure they do not interfere with multithreading
-    options.dispatch = cglobal((:dispatch_graph, libnauty), Cvoid)
-    options.getcanon = canonical_form
-    options.digraph = is_directed(g)
-    options.defaultptn = ignore_vertex_labels || all(iszero, g.labels) # TODO: check more carefully if lab/ptn is valid
-
-    stats = NautyStatistics()
-
     lab, ptn = _vertexlabels_to_labptn(g.labels)
-
     orbits = zeros(Cint, n)
-    h = zero(g.graphset)
+    canong = zero(g.graphset)
 
     @ccall libnauty.densenauty(
         g.graphset::Ref{WordType},
@@ -89,55 +79,69 @@ function nauty(g::DenseNautyGraph, canonical_form=true; ignore_vertex_labels=fal
         ptn::Ref{Cint},
         orbits::Ref{Cint},
         Ref(options)::Ref{NautyOptions},
-        Ref(stats)::Ref{NautyStatistics},
+        Ref(statistics)::Ref{NautyStatistics},
         m::Cint,
         n::Cint,
-        h::Ref{WordType})::Cvoid
+        canong::Ref{WordType})::Cvoid
 
-    # TODO: clean this up
-    if stats.grpsize1 * 10^stats.grpsize2 < typemax(Int)
-        grpsize = round(Int, stats.grpsize1 * 10^stats.grpsize2)
-    else
-        @warn "automorphism group size overflow"
-        grpsize = 0
-    end
-    
-    # autmorph = AutomorphismGroup{T}(grpsize, orbits, stats.numgenerators) # TODO: summarize useful automorphism group info
-
-    if canonical_form
-        canong = h
-        canon_perm = lab .+ 1
-    else
-        canong = nothing
-        canon_perm = nothing
-    end
-    return grpsize, canong, canon_perm
+    canonperm = (lab .+= 1)
+    return canong, canonperm, orbits, statistics
 end
 
-function _nautyhash(g::DenseNautyGraph)
-    grpsize, canong, canon_perm = nauty(g, true)
-
+function _sethash!(g::DenseNautyGraph, canong, canonperm)
     # Base.hash skips elements in arrays of length >= 8192
     # Use SHA in these cases
     canong_hash = length(canong) >= 8192 ? hash_sha(canong) : hash(canong)
-    labels_hash = @views length(g.labels) >= 8192 ? hash_sha(g.labels[canon_perm]) : hash(g.labels[canon_perm])
+    labels_hash = @views length(g.labels) >= 8192 ? hash_sha(g.labels[canonperm]) : hash(g.labels[canonperm])
 
     hashval = hash(labels_hash, canong_hash)
     g.hashval = hashval
-    return grpsize, canong, canon_perm, hashval
+    return
+end
+function _canonize!(g::DenseNautyGraph, canong, canonperm)
+    copyto!(g.graphset, canong)
+    permute!(g.labels, canonperm)
+    return
 end
 
+
+"""
+    nauty(g::AbstractNautyGraph, [options::NautyOptions]; [canonize=false])
+
+Compute a graph g's canonical form and automorphism group. Also computes g's graph hash, which can then be retrieved without duplicate computations via `ghash(g)`.
+"""
+function nauty(::AbstractNautyGraph, ::NautyOptions; kwargs...) end
+
+function nauty(g::DenseNautyGraph, options::NautyOptions=defaultoptions(g); canonize=false)
+    if options.digraph != is_directed(g)
+        error("Nauty options need to match the directedness of the input graph. Make sure to instantiate options with `digraph=true` if the input graph is directed.")
+    end
+    if !isone(options.getcanon)
+        error("`options.getcanon` needs to be enabled.")
+    end
+
+    canong, canonperm, orbits, statistics = _densenauty(g, options)
+    _sethash!(g, canong, canonperm)
+
+    # generators = Vector{Cint}[] # TODO: extract generators from nauty call
+    autg = AutomorphismGroup(statistics.grpsize1 * 10^statistics.grpsize2, orbits)
+    if canonize
+        _canonize!(g, canong, canonperm)
+    end
+    return canonperm, autg
+end
 
 """
     canonize!(g::AbstractNautyGraph)
 
-Reorder g's vertices to be in canonical order. Returns the permutation used to canonize g and the automorphism group size.
+Reorder g's vertices to be in canonical order. Returns the permutation used to canonize g and the automorphism group.
 """
-function canonize!(g::AbstractNautyGraph)
-    grpsize, canong, canon_perm, hashval = _nautyhash(g)
-    copyto!(g.graphset, canong)
-    permute!(g.labels, canon_perm)
-    return canon_perm, grpsize
+function canonize!(::AbstractNautyGraph) end
+
+function canonize!(g::DenseNautyGraph)
+    canong, canonperm, _ = _densenauty(g)
+    _canonize!(g, canong, canonperm)
+    return canonperm
 end
 
 """
@@ -145,13 +149,14 @@ end
 
 Check whether two graphs g and h are isomorphic to each other by comparing their canonical forms.
 """
-function is_isomorphic(g::AbstractNautyGraph, h::AbstractNautyGraph)
-    _, canong, permg = nauty(g, true)
-    _, canonh, permh = nauty(h, true)
+function is_isomorphic(::AbstractNautyGraph, ::AbstractNautyGraph) end
+
+function is_isomorphic(g::DenseNautyGraph, h::DenseNautyGraph)
+    canong, permg, _ = _densenauty(g)
+    canonh, permh, _ = _densenauty(h)
     return canong == canonh && view(g.labels, permg) == view(h.labels, permh)
 end
 ≃(g::AbstractNautyGraph, h::AbstractNautyGraph) = is_isomorphic(g, h)
-
 
 
 """
@@ -160,16 +165,14 @@ end
 Hash the canonical version of g, so that (up to hash collisions) `ghash(g1) == ghash(g2)` implies `is_isomorphic(g1, g2) == true`.
 Hashes are computed using `Base.hash` for small graphs (nv < 8192), or using the first 64 bits of `sha256` for larger graphs.
 """
-function ghash(g::AbstractNautyGraph)
+function ghash(::AbstractNautyGraph) end
+
+function ghash(g::DenseNautyGraph)
     if !isnothing(g.hashval)
         return g.hashval
     end
 
-    _, _, _, hashval = _nautyhash(g)
-    g.hashval = hashval
+    canong, canonperm, _ = _densenauty(g, defaultoptions(g))
+    _sethash!(g, canong, canonperm)
     return g.hashval
 end
-
-# TODO: decide what the default equality comparision should be
-Base.hash(g::DenseNautyGraph, h::UInt) = hash(g.labels, hash(g.graphset, h))
-Base.:(==)(g::DenseNautyGraph, h::DenseNautyGraph) = (g.graphset == h.graphset) && (g.labels == h.labels)

--- a/src/nauty.jl
+++ b/src/nauty.jl
@@ -145,6 +145,18 @@ function canonize!(g::DenseNautyGraph)
 end
 
 """
+    canonical_permutation(g::AbstractNautyGraph)
+
+Return the permutation `p` needed to canonize `g`. This permutation satisfies `g[p] = canong`.
+"""
+function canonical_permutation(::AbstractNautyGraph) end
+
+function canonical_permutation(g::DenseNautyGraph)
+    _, canonperm, _ = _densenauty(g)
+    return canonperm
+end
+
+"""
     is_isomorphic(g::AbstractNautyGraph, h::AbstractNautyGraph)
 
 Check whether two graphs `g` and `h` are isomorphic to each other by comparing their canonical forms.

--- a/src/nauty.jl
+++ b/src/nauty.jl
@@ -121,10 +121,10 @@ function nauty(g::DenseNautyGraph, options::NautyOptions=defaultoptions(g); cano
     end
 
     canong, canonperm, orbits, statistics = _densenauty(g, options)
-    _sethash!(g, canong, canonperm)
-
     # generators = Vector{Cint}[] # TODO: extract generators from nauty call
     autg = AutomorphismGroup(statistics.grpsize1 * 10^statistics.grpsize2, orbits)
+
+    _sethash!(g, canong, canonperm)
     if canonize
         _canonize!(g, canong, canonperm)
     end
@@ -140,6 +140,7 @@ function canonize!(::AbstractNautyGraph) end
 
 function canonize!(g::DenseNautyGraph)
     canong, canonperm, _ = _densenauty(g)
+    _sethash!(g, canong, canonperm)
     _canonize!(g, canong, canonperm)
     return canonperm
 end

--- a/test/densenautygraphs.jl
+++ b/test/densenautygraphs.jl
@@ -55,12 +55,16 @@ end
     @test nv(empty_g) == 0
     @test ne(empty_g) == 0
     
-    rand_g = NautyGraph(erdos_renyi(70, 100; rng=rng))
+    g0 = erdos_renyi(70, 100; rng=rng)
+    rand_g = NautyGraph(g0)
     @test nv(rand_g) == 70
     @test ne(rand_g) == 100
     @test vertices(rand_g) == Base.OneTo(70)
 
     for edge in edges(rand_g)
+        @test has_edge(rand_g, edge)
+    end
+    for edge in edges(g0)
         @test has_edge(rand_g, edge)
     end
     for vertex in vertices(rand_g)

--- a/test/densenautygraphs.jl
+++ b/test/densenautygraphs.jl
@@ -57,7 +57,7 @@ end
     
     g0 = erdos_renyi(70, 100; rng=rng)
     rand_g = NautyGraph(g0)
-    @test_throws "Cannot create an undirected NautyGraph from a directed graph" (rand_g_dir = NautyDiGraph(g0))
+    @test_throws ErrorException (rand_g_dir = NautyDiGraph(g0))
 
     @test nv(rand_g) == 70
     @test ne(rand_g) == 100

--- a/test/densenautygraphs.jl
+++ b/test/densenautygraphs.jl
@@ -48,6 +48,37 @@ symmetrize_adjmx(A) = (A = convert(typeof(A), (A + A') .> 0); for i in axes(A, 1
         add_edge!(ng, 1, 2)
         @test adjacency_matrix(g) == adjacency_matrix(ng)
     end
+
+    g_loop = Graph(2)
+    ng_loop = NautyGraph(2)
+
+    add_edge!(g_loop, 1, 1)
+    add_edge!(ng_loop, 1, 1)
+    @test ne(ng_loop) == ne(g_loop)
+
+    @test adjacency_matrix(ng_loop) == adjacency_matrix(g_loop)
+
+    add_edge!(g_loop, 1, 2)
+    add_edge!(ng_loop, 1, 2)
+    @test ne(ng_loop) == ne(g_loop)
+
+    g_diloop = DiGraph(2)
+    ng_diloop = NautyDiGraph(2)
+    add_edge!(g_diloop, 1, 1)
+    add_edge!(ng_diloop, 1, 1)
+    @test ne(ng_diloop) == ne(g_diloop)
+
+    @test adjacency_matrix(ng_diloop) == adjacency_matrix(g_diloop)
+
+    add_edge!(g_diloop, 1, 1)
+    @test add_edge!(ng_diloop, 1, 1) == false
+    @test ne(ng_diloop) == ne(g_diloop)
+
+    @test adjacency_matrix(ng_diloop) == adjacency_matrix(g_diloop)
+
+    add_edge!(g_diloop, 1, 2)
+    add_edge!(ng_diloop, 1, 2)
+    @test ne(ng_diloop) == ne(g_diloop)
 end
 
 @testset "methods" begin
@@ -74,7 +105,6 @@ end
         @test outdegree(rand_g, vertex) == length(outneighbors(rand_g, vertex))
         @test indegree(rand_g, vertex) == length(inneighbors(rand_g, vertex))
     end
-
 
     g = NautyDiGraph(4)
     add_edge!(g, 1, 2)

--- a/test/densenautygraphs.jl
+++ b/test/densenautygraphs.jl
@@ -57,6 +57,8 @@ end
     
     g0 = erdos_renyi(70, 100; rng=rng)
     rand_g = NautyGraph(g0)
+    @test_throws "Cannot create an undirected NautyGraph from a directed graph" (rand_g_dir = NautyDiGraph(g0))
+
     @test nv(rand_g) == 70
     @test ne(rand_g) == 100
     @test vertices(rand_g) == Base.OneTo(70)
@@ -72,6 +74,7 @@ end
         @test outdegree(rand_g, vertex) == length(outneighbors(rand_g, vertex))
         @test indegree(rand_g, vertex) == length(inneighbors(rand_g, vertex))
     end
+
 
     g = NautyDiGraph(4)
     add_edge!(g, 1, 2)

--- a/test/nauty.jl
+++ b/test/nauty.jl
@@ -102,4 +102,27 @@ using Base.Threads
         push!(vals, nauty(thread_gs[i]))
     end
     @test length(vals) == length(thread_gs)
+
+
+    gnoloop = NautyGraph(5)
+    add_edge!(gnoloop, 1, 2)
+    add_edge!(gnoloop, 3, 5)
+    add_edge!(gnoloop, 5, 2)
+
+    gloop = copy(gnoloop)
+    add_edge!(gloop, 1, 1)
+
+    @test_nowarn nauty(gloop)
+    @test !is_isomorphic(gnoloop, gloop)
+
+    gdinoloop = NautyDiGraph(5)
+    add_edge!(gdinoloop, 1, 2)
+    add_edge!(gdinoloop, 3, 5)
+    add_edge!(gdinoloop, 5, 2)
+
+    gdiloop = copy(gdinoloop)
+    add_edge!(gdiloop, 1, 1)
+
+    @test_nowarn nauty(gdiloop)
+    @test !is_isomorphic(gdinoloop, gdiloop)
 end

--- a/test/nauty.jl
+++ b/test/nauty.jl
@@ -3,7 +3,7 @@ using Base.Threads
 @testset "nauty" begin
     verylarge_g = NautyGraph(50)
 
-    canonperm, autg = nauty(verylarge_g)
+    _, autg = nauty(verylarge_g)
     @test autg.n > typemax(Int64)
 
     g1 = NautyGraph(4)
@@ -81,6 +81,20 @@ using Base.Threads
     g4.hashval = UInt(0)
     @test g4 == h4
     @test Base.hash(g4) == Base.hash(h4)
+
+
+    g5 = NautyGraph(10, collect(10:-1:1))
+    add_edge!(g5, 1, 2)
+    add_edge!(g5, 5, 2)
+    add_edge!(g5, 6, 7)
+    add_edge!(g5, 8, 1)
+    add_edge!(g5, 9, 10)
+
+    canon5 = copy(g5)
+    canonize!(canon5)
+
+    canonperm5 = canonical_permutation(g5)
+    @test canon5.labels == g5.labels[canonperm5]
 
     thread_gs = fill(copy(g4), 10)
     vals = []

--- a/test/nauty.jl
+++ b/test/nauty.jl
@@ -1,11 +1,10 @@
 using Base.Threads
 
 @testset "nauty" begin
-    overflow_g = NautyGraph(50)
+    verylarge_g = NautyGraph(50)
 
-    # Check group size overflow
-    grpsize, _, _ = nauty(overflow_g)
-    @test grpsize == 0
+    canonperm, autg = nauty(verylarge_g)
+    @test autg.n > typemax(Int64)
 
     g1 = NautyGraph(4)
     add_edge!(g1, 1, 2)

--- a/test/nauty.jl
+++ b/test/nauty.jl
@@ -1,3 +1,5 @@
+using Base.Threads
+
 @testset "nauty" begin
     overflow_g = NautyGraph(50)
 
@@ -80,4 +82,11 @@
     g4.hashval = UInt(0)
     @test g4 == h4
     @test Base.hash(g4) == Base.hash(h4)
+
+    thread_gs = fill(copy(g4), 10)
+    vals = []
+    @threads for i in eachindex(thread_gs)
+        push!(vals, nauty(thread_gs[i]))
+    end
+    @test length(vals) == length(thread_gs)
 end


### PR DESCRIPTION
This PR introduces a better defined public interface.
Main changes:
- `nauty` can now be used to obtain information about the automorphism group of a graph. As of now, the group information is very limited, but in the future it should include e.g. the generators of the automorphism group.
- There now is a `AutomorphismGroup` type. Right now, it only holds the group size and orbits.
- `canonize!` now returns just the canonical permutation. If you want automorphism group info and canonization at the same time, use `nauty(g; canonize=true)`.